### PR TITLE
cicd: update almaslennikov/multus-cni images tags to 18e12ac in chart values

### DIFF
--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-full.yaml
@@ -89,8 +89,8 @@ spec:
       version: v1.2.1
     multus:
       image: multus-cni
-      repository: ghcr.io/k8snetworkplumbingwg
-      version: v4.1.0
+      repository: ghcr.io/almaslennikov
+      version: 18e12ac
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-ipoib.yaml
@@ -67,8 +67,8 @@ spec:
       version: v1.2.1
     multus:
       image: multus-cni
-      repository: ghcr.io/k8snetworkplumbingwg
-      version: v4.1.0
+      repository: ghcr.io/almaslennikov
+      version: 18e12ac
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr-nvidia-ipam.yaml
@@ -63,8 +63,8 @@ spec:
       version: v1.5.0
     multus:
       image: multus-cni
-      repository: ghcr.io/k8snetworkplumbingwg
-      version: v4.1.0
+      repository: ghcr.io/almaslennikov
+      version: 18e12ac
   nvIpam:
     image: nvidia-k8s-ipam
     repository: ghcr.io/mellanox

--- a/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
+++ b/example/crs/mellanox.com_v1alpha1_nicclusterpolicy_cr.yaml
@@ -63,8 +63,8 @@ spec:
       version: v1.5.0
     multus:
       image: multus-cni
-      repository: ghcr.io/k8snetworkplumbingwg
-      version: v4.1.0
+      repository: ghcr.io/almaslennikov
+      version: 18e12ac
     ipamPlugin:
       image: whereabouts
       repository: ghcr.io/k8snetworkplumbingwg

--- a/hack/release.yaml
+++ b/hack/release.yaml
@@ -48,8 +48,8 @@ CniPlugins:
   version: v1.5.0
 Multus:
   image: multus-cni
-  repository: ghcr.io/k8snetworkplumbingwg
-  version: v4.1.0
+  repository: ghcr.io/almaslennikov
+  version: 18e12ac
 Ipoib:
   image: ipoib-cni
   repository: ghcr.io/mellanox


### PR DESCRIPTION
Created by the *update_network_operator_values* job.